### PR TITLE
tmux: colorize status bar per TMNT-themed devbox

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -13,6 +13,13 @@ set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g mouse on
 
 # ---------------------------------------------------------------------------
+# Status bar: show devbox instance name instead of UUID, colored per TMNT box
+# ---------------------------------------------------------------------------
+set -g status-right '"#($HOME/dotfiles/bin/devbox-name)" %H:%M %d-%b-%y'
+# status-style has no #() dynamic eval, so resolve once at load time
+run-shell 'tmux set -g status-style "bg=$($HOME/dotfiles/bin/devbox-tmux-color),fg=black"'
+
+# ---------------------------------------------------------------------------
 # Initialize TPM (keep this line at the very bottom of tmux.conf)
 # ---------------------------------------------------------------------------
 run '~/.tmux/plugins/tpm/tpm'

--- a/bin/devbox-name
+++ b/bin/devbox-name
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Echo the devbox instance name, falling back to $(hostname) off-devbox.
+# Mirrors the logic in ~/figma/figma/.devcontainer/personalization/ps1.sh
+echo "${FIGMA_CODER_WORKSPACE_NAME:-$(cat /home/ubuntu/.config/devbox/instance_name 2>/dev/null || hostname)}"

--- a/bin/devbox-tmux-color
+++ b/bin/devbox-tmux-color
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Emit a tmux color name for the current devbox's TMNT theme.
+# Used by status-style in ~/dotfiles/.tmux.conf.
+name="${FIGMA_CODER_WORKSPACE_NAME:-$(cat /home/ubuntu/.config/devbox/instance_name 2>/dev/null || hostname)}"
+case "$name" in
+  *raph*)  echo "colour160" ;; # red
+  *leo*)   echo "colour33" ;;  # blue
+  *mikey*) echo "colour208" ;; # orange
+  *don*)   echo "colour135" ;; # purple
+  *)       echo "colour76" ;;  # default green (tmux default)
+esac


### PR DESCRIPTION
Describe:
- Extend the TMNT-per-devbox theming (merged in #7 for the zsh prompt) to the tmux status bar so each Coder workspace is unmistakable at a glance. Previously the bar was green everywhere with an opaque UUID in `status-right`.

## What changes

Two helper scripts in `bin/` resolve the devbox name using the same `FIGMA_CODER_WORKSPACE_NAME` / `instance_name` logic as `ps1.sh`:

- `bin/devbox-name` — used in `status-right` via `#()` so the UUID is replaced with `raph` / `leo` / `mikey` / `don`
- `bin/devbox-tmux-color` — maps the name to a tmux color; `status-style` bg is set once at load via `run-shell`

> [!NOTE]
> `status-style` is set via `run-shell` rather than inline because tmux doesn't evaluate `#()` for style options.

## Behavior

- raph → red (colour160)
- leo → blue (colour33)
- mikey → orange (colour208)
- don → purple (colour135)
- unknown / local → green (tmux's default, so local tmux is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)